### PR TITLE
Conforming with PEP517 and PEP518

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,3 @@
+# Default ignored files
+/shelf/
+/workspace.xml

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.10 (oculy)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/oculy.iml" filepath="$PROJECT_DIR$/.idea/oculy.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/oculy.iml
+++ b/.idea/oculy.iml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
+    <orderEntry type="jdk" jdkName="Python 3.10 (oculy)" jdkType="Python SDK" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="PyDocumentationSettings">
+    <option name="format" value="PLAIN" />
+    <option name="myDocStringFormat" value="Plain" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ package first::
     pip install build
 
 OThis should create a `build/` folder as well as a `dist/` folder
-(don’t forget to add these to your `.gitignore`, if they aren’t in there already.
+(don't forget to add these to your `.gitignore`, if they aren't in there already.
 
 you can now build your package by running::
 
@@ -37,7 +37,12 @@ do so by running::
 
 from the directory where the `pyproject.toml` resides. Any changes you make to the source code
 will take immediate effect.
+Now you can run oculy by typing either::
 
-    python -m  oculy
+    oculy
+
+or::
+
+    python -m oculy
 
 The second option allow you to see the program console output and can be useful to debug issues.

--- a/README.rst
+++ b/README.rst
@@ -4,17 +4,39 @@ Oculy: Modular data viewer
 Installation
 ------------
 
-Currently Oculy cannot be installed directly due to one of its dependency not
-being available on PyPI. To install it directly from GitHub, you can::
+First, all you need is to clone the repository of oculy on your local machine::
 
-    pip install git+https://github.com/MatthieuDartiailh/glaze
-    pip install git+https://github.com/MatthieuDartiailh/oculy
+    git clone https://github.com/MatthieuDartiailh/oculy.git
 
-Once installed Oculy can be started by either running::
+Now that you cloned oculy, you are to to build your package. You may need to install the build
+package first::
 
-    oculy
+    pip install build
 
-or::
+OThis should create a `build/` folder as well as a `dist/` folder
+(don’t forget to add these to your `.gitignore`, if they aren’t in there already.
+
+you can now build your package by running::
+
+ python -m build --wheel
+
+from the folder where the `pyproject.toml` resides. In `dist/` folder you will find a wheel
+named `oculy-0.0.0-py2.py3-none-any.whl`. That file contains your package, and this is all
+you need to distribute it. You can install this package anywhere by copying it to the relevant
+machine and running::
+
+    pip install oculy-0.0.0-py2.py3-none-any.whl
+
+When developing you probably do not want to re-build and re-install the wheel every time you
+have made a change to the code, and for that you can use an editable install. This will install
+your package without packaging it into a file, but by referring to the source directory. You can
+do so by running::
+
+
+    pip install -e .
+
+from the directory where the `pyproject.toml` resides. Any changes you make to the source code
+will take immediate effect.
 
     python -m  oculy
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,0 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from setuptools import setup
-
-if __name__ == "__main__":
-    setup(use_scm_version=True)


### PR DESCRIPTION
In this PR, I have tried to get the installation of oculy conformed with PEP517 and PEP518 by replacing setup.py by pyproject.toml and updating the README as a guideline to build oculy package.